### PR TITLE
Add workspace support for organizing tags into separate sets

### DIFF
--- a/ClipCull/ClipCull/Controls/ClipFilterControl.xaml.cs
+++ b/ClipCull/ClipCull/Controls/ClipFilterControl.xaml.cs
@@ -56,12 +56,25 @@ namespace ClipCull.Controls
             InitializeComponent();
             DataContext = this;
 
-            // Set up TaggingControl with available tags
-            var availableTags = new ObservableCollection<Tag>();
-            SettingsHandler.Settings.Tags.ForEach(tag => availableTags.Add(tag));
-            TagFilterControl.AvailableTags = availableTags;
+            // Set up TaggingControl with available tags from the active workspace
+            RefreshAvailableTags();
+
+            // Refresh the filter dropdown when the active workspace changes
+            SettingsHandler.WorkspaceChanged += OnWorkspaceChanged;
 
             this.Loaded += ClipFilterControl_Loaded;
+        }
+
+        private void RefreshAvailableTags()
+        {
+            var availableTags = new ObservableCollection<Tag>();
+            SettingsHandler.GetCurrentWorkspaceTags().ForEach(tag => availableTags.Add(tag));
+            TagFilterControl.AvailableTags = availableTags;
+        }
+
+        private void OnWorkspaceChanged()
+        {
+            Dispatcher.Invoke(RefreshAvailableTags);
         }
 
         private void ClipFilterControl_Loaded(object sender, RoutedEventArgs e)

--- a/ClipCull/ClipCull/Controls/FolderTreeControl.xaml
+++ b/ClipCull/ClipCull/Controls/FolderTreeControl.xaml
@@ -365,43 +365,48 @@
                               Style="{StaticResource small}"
                               Foreground="{StaticResource MutedForegroundBrush}"/>
 
-                    <StackPanel Grid.Column="1" 
-                               Orientation="Horizontal">
+                    <StackPanel Grid.Column="1"
+                               Orientation="Horizontal"
+                               VerticalAlignment="Center">
 
-                        <!-- Custom Checkbox Style -->
-                        <CheckBox x:Name="ShowFilesCheckBox"
-                                 Content="Show Files"
-                                 IsChecked="{Binding ShowFiles, RelativeSource={RelativeSource AncestorType=local:FolderTreeControl}}"
+                        <!-- Compact "folders only" toggle -->
+                        <CheckBox x:Name="ShowFoldersOnlyCheckBox"
+                                 Content="Folders only"
+                                 IsChecked="{Binding ShowFoldersOnly, RelativeSource={RelativeSource AncestorType=local:FolderTreeControl}}"
                                  Checked="ShowFilesCheckBox_Changed"
                                  Unchecked="ShowFilesCheckBox_Changed"
-                                 Foreground="{StaticResource ForegroundBrush}"
-                                 Margin="0,0,12,0">
+                                 Cursor="Hand"
+                                 ToolTip="Hide files and only show folders in the tree"
+                                 VerticalAlignment="Center">
                             <CheckBox.Style>
                                 <Style TargetType="CheckBox">
                                     <Setter Property="Template">
                                         <Setter.Value>
                                             <ControlTemplate TargetType="CheckBox">
-                                                <StackPanel Orientation="Horizontal">
+                                                <StackPanel Orientation="Horizontal" Background="Transparent">
                                                     <Border x:Name="CheckBorder"
-                                                           Width="16" Height="16"
-                                                           Background="{StaticResource InputBrush}"
-                                                           BorderBrush="{StaticResource BorderBrush}"
+                                                           Width="13" Height="13"
+                                                           Background="Transparent"
+                                                           BorderBrush="{StaticResource MutedForegroundBrush}"
                                                            BorderThickness="1"
                                                            CornerRadius="3"
-                                                           Margin="0,0,6,0">
+                                                           Margin="0,0,5,0"
+                                                           VerticalAlignment="Center">
                                                         <materialDesign:PackIcon x:Name="CheckIcon"
                                                                                Kind="Check"
-                                                                               Width="12" Height="12"
-                                                                               Foreground="{StaticResource ForegroundBrush}"
+                                                                               Width="10" Height="10"
+                                                                               Foreground="{StaticResource AccentForegroundBrush}"
                                                                                Visibility="Collapsed"/>
                                                     </Border>
-                                                    <ContentPresenter VerticalAlignment="Center"/>
+                                                    <ContentPresenter VerticalAlignment="Center"
+                                                                      TextElement.FontSize="11"
+                                                                      TextElement.Foreground="{StaticResource MutedForegroundBrush}"/>
                                                 </StackPanel>
                                                 <ControlTemplate.Triggers>
                                                     <Trigger Property="IsChecked" Value="True">
                                                         <Setter TargetName="CheckIcon" Property="Visibility" Value="Visible"/>
-                                                        <Setter TargetName="CheckBorder" Property="Background" Value="{StaticResource PrimaryBrush}"/>
-                                                        <Setter TargetName="CheckBorder" Property="BorderBrush" Value="{StaticResource PrimaryBrush}"/>
+                                                        <Setter TargetName="CheckBorder" Property="Background" Value="{StaticResource AccentBrush}"/>
+                                                        <Setter TargetName="CheckBorder" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
                                                     </Trigger>
                                                     <Trigger Property="IsMouseOver" Value="True">
                                                         <Setter TargetName="CheckBorder" Property="BorderBrush" Value="{StaticResource RingBrush}"/>
@@ -413,10 +418,6 @@
                                 </Style>
                             </CheckBox.Style>
                         </CheckBox>
-
-                        <TextBlock Text="{Binding FileFilter, RelativeSource={RelativeSource AncestorType=local:FolderTreeControl}}" 
-                                  Style="{StaticResource small}"
-                                  Foreground="{StaticResource MutedForegroundBrush}"/>
                     </StackPanel>
                 </Grid>
             </Border>

--- a/ClipCull/ClipCull/Controls/FolderTreeControl.xaml.cs
+++ b/ClipCull/ClipCull/Controls/FolderTreeControl.xaml.cs
@@ -121,6 +121,10 @@ namespace ClipCull.Controls
 
         #region Events
         public event EventHandler<FolderSelectedEventArgs> FolderSelected;
+        /// <summary>
+        /// Raised when a new root folder is loaded into the browser (e.g. via Select Folder).
+        /// </summary>
+        public event EventHandler<FolderSelectedEventArgs> FolderLoaded;
         public event EventHandler<FileSelectedEventArgs> FileSelected;
         public event EventHandler<PathChangedEventArgs> PathChanged;
         public event EventHandler<FolderDoubleClickEventArgs> FolderDoubleClick;
@@ -158,6 +162,8 @@ namespace ClipCull.Controls
         public void LoadFolder(string rootPath)
         {
             RootPath = rootPath;
+            if (!string.IsNullOrEmpty(rootPath))
+                FolderLoaded?.Invoke(this, new FolderSelectedEventArgs(rootPath));
         }
 
         public async void JumpToFolder(string path)

--- a/ClipCull/ClipCull/Controls/FolderTreeControl.xaml.cs
+++ b/ClipCull/ClipCull/Controls/FolderTreeControl.xaml.cs
@@ -64,6 +64,7 @@ namespace ClipCull.Controls
                     var currentSelectedPath = SelectedPath; // Remember current selection
                     _showFiles = value;
                     OnPropertyChanged(nameof(ShowFiles));
+                    OnPropertyChanged(nameof(ShowFoldersOnly));
                     RefreshCurrentFolder();
 
                     // Try to restore selection after refresh
@@ -77,6 +78,15 @@ namespace ClipCull.Controls
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Inverse of <see cref="ShowFiles"/>. When true only folders are shown in the tree.
+        /// </summary>
+        public bool ShowFoldersOnly
+        {
+            get => !ShowFiles;
+            set => ShowFiles = !value;
         }
 
         public string FileFilter

--- a/ClipCull/ClipCull/Controls/SettingsControl.xaml
+++ b/ClipCull/ClipCull/Controls/SettingsControl.xaml
@@ -199,11 +199,24 @@
                                           ToolTip="Tags are managed separately per workspace"/>
                                 <TextBox Name="TbWorkspaceName" Width="160" Margin="16,0,0,0" VerticalContentAlignment="Center"
                                          Foreground="{StaticResource ForegroundBrush}" BorderBrush="{StaticResource BorderBrush}" Background="{StaticResource BackgroundBrush}"
-                                         ToolTip="Name used when adding or renaming a workspace"/>
+                                         ToolTip="Name used when adding, renaming or duplicating a workspace"/>
                                 <Button Name="BtnAddWorkspace" Content="Add" Margin="6,0,0,0" Style="{StaticResource primary-sm}" Click="BtnAddWorkspace_Click"/>
+                                <Button Name="BtnDuplicateWorkspace" Content="Duplicate" Margin="6,0,0,0" Style="{StaticResource secondary-sm}" Click="BtnDuplicateWorkspace_Click"/>
                                 <Button Name="BtnRenameWorkspace" Content="Rename" Margin="6,0,0,0" Style="{StaticResource secondary-sm}" Click="BtnRenameWorkspace_Click"/>
                                 <Button Name="BtnDeleteWorkspace" Content="Delete" Margin="6,0,0,0" Style="{StaticResource secondary-sm}" Click="BtnDeleteWorkspace_Click"/>
                             </StackPanel>
+
+                            <!-- Move / copy selected tags to another workspace -->
+                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                <TextBlock Style="{StaticResource h4}" VerticalAlignment="Center" Margin="0,0,8,0">Selected tags →</TextBlock>
+                                <ComboBox Name="CbTargetWorkspace" Width="180" VerticalAlignment="Center"
+                                          ToolTip="Target workspace for the selected tags"/>
+                                <Button Name="BtnCopyTags" Content="Copy" Margin="6,0,0,0" Style="{StaticResource secondary-sm}" Click="BtnCopyTags_Click"
+                                        ToolTip="Copy the tags selected in the list to the target workspace"/>
+                                <Button Name="BtnMoveTags" Content="Move" Margin="6,0,0,0" Style="{StaticResource secondary-sm}" Click="BtnMoveTags_Click"
+                                        ToolTip="Move the tags selected in the list to the target workspace"/>
+                            </StackPanel>
+
                             <TextBlock Style="{StaticResource small}" Foreground="{StaticResource MutedForegroundBrush}" Margin="0,6,0,0"
                                        TextWrapping="Wrap">
                                 Tags below belong to the selected workspace. Switch the active workspace from the status bar in the Editing tab. Existing labels on clips always load regardless of the active workspace.

--- a/ClipCull/ClipCull/Controls/SettingsControl.xaml
+++ b/ClipCull/ClipCull/Controls/SettingsControl.xaml
@@ -183,7 +183,36 @@
                 </Grid>
             </TabItem>
             <TabItem Header="Tags">
-                <local:TagManagementControl x:Name="TagManagement"  AllowDuplicateNames="False" MaxTagNameLength="20"/>
+                <Grid Margin="8">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <!-- Workspace management bar -->
+                    <Border Grid.Row="0" Style="{StaticResource card}" Margin="0,0,0,8" Padding="12,10">
+                        <StackPanel Orientation="Vertical">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Style="{StaticResource h4}" VerticalAlignment="Center" Margin="0,0,8,0">Workspace</TextBlock>
+                                <ComboBox Name="CbTagWorkspace" Width="180" VerticalAlignment="Center"
+                                          SelectionChanged="CbTagWorkspace_SelectionChanged"
+                                          ToolTip="Tags are managed separately per workspace"/>
+                                <TextBox Name="TbWorkspaceName" Width="160" Margin="16,0,0,0" VerticalContentAlignment="Center"
+                                         Foreground="{StaticResource ForegroundBrush}" BorderBrush="{StaticResource BorderBrush}" Background="{StaticResource BackgroundBrush}"
+                                         ToolTip="Name used when adding or renaming a workspace"/>
+                                <Button Name="BtnAddWorkspace" Content="Add" Margin="6,0,0,0" Style="{StaticResource primary-sm}" Click="BtnAddWorkspace_Click"/>
+                                <Button Name="BtnRenameWorkspace" Content="Rename" Margin="6,0,0,0" Style="{StaticResource secondary-sm}" Click="BtnRenameWorkspace_Click"/>
+                                <Button Name="BtnDeleteWorkspace" Content="Delete" Margin="6,0,0,0" Style="{StaticResource secondary-sm}" Click="BtnDeleteWorkspace_Click"/>
+                            </StackPanel>
+                            <TextBlock Style="{StaticResource small}" Foreground="{StaticResource MutedForegroundBrush}" Margin="0,6,0,0"
+                                       TextWrapping="Wrap">
+                                Tags below belong to the selected workspace. Switch the active workspace from the status bar in the Editing tab. Existing labels on clips always load regardless of the active workspace.
+                            </TextBlock>
+                        </StackPanel>
+                    </Border>
+
+                    <local:TagManagementControl Grid.Row="1" x:Name="TagManagement" AllowDuplicateNames="False" MaxTagNameLength="20"/>
+                </Grid>
             </TabItem>
             <TabItem Header="Hotkeys">
                 <local:HotkeySettingsControl x:Name="HotkeyView" />

--- a/ClipCull/ClipCull/Controls/SettingsControl.xaml.cs
+++ b/ClipCull/ClipCull/Controls/SettingsControl.xaml.cs
@@ -28,6 +28,13 @@ namespace ClipCull.Controls
     {
         private bool _isLoading;
 
+        /// <summary>
+        /// Working copy of the workspaces being edited. Changes are committed to settings on Save.
+        /// </summary>
+        private List<Workspace> _editWorkspaces = new List<Workspace>();
+        private Workspace _selectedEditWorkspace;
+        private bool _isLoadingWorkspaces;
+
         public SettingsControl()
         {
             InitializeComponent();
@@ -45,17 +52,210 @@ namespace ClipCull.Controls
 
             PopulateRenderSettingsControls();
 
-            //Tags
-            var tagCollection = new ObservableCollection<EditableTag>();
-            SettingsHandler.Settings.Tags.ForEach(x => tagCollection.Add(new EditableTag
-            {
-                Color = x.Color,
-                Name = x.Name
-            }));
-            TagManagement.Tags = tagCollection;
+            //Tags (per workspace)
+            LoadWorkspacesIntoEditor();
 
             _isLoading = false;
         }
+
+        #region Tag Workspaces
+
+        /// <summary>
+        /// Builds a working copy of the workspaces and populates the workspace selector.
+        /// </summary>
+        private void LoadWorkspacesIntoEditor()
+        {
+            _isLoadingWorkspaces = true;
+            try
+            {
+                _editWorkspaces = SettingsHandler.Settings.Workspaces
+                    .Select(CloneWorkspace)
+                    .ToList();
+
+                if (_editWorkspaces.Count == 0)
+                    _editWorkspaces.Add(new Workspace { Name = SettingsHandler.DefaultWorkspaceName });
+
+                CbTagWorkspace.Items.Clear();
+                foreach (var ws in _editWorkspaces)
+                    CbTagWorkspace.Items.Add(ws.Name);
+
+                // Prefer the currently active workspace as the initial selection.
+                var initial = _editWorkspaces.FirstOrDefault(w =>
+                                  string.Equals(w.Name, SettingsHandler.Settings.CurrentWorkspaceName, StringComparison.OrdinalIgnoreCase))
+                              ?? _editWorkspaces[0];
+
+                _selectedEditWorkspace = initial;
+                CbTagWorkspace.SelectedItem = initial.Name;
+                LoadWorkspaceTags(initial);
+            }
+            finally
+            {
+                _isLoadingWorkspaces = false;
+            }
+        }
+
+        private static Workspace CloneWorkspace(Workspace source)
+        {
+            return new Workspace
+            {
+                Name = source.Name,
+                Tags = (source.Tags ?? new List<Tag>())
+                    .Select(t => new Tag { Name = t.Name, Color = t.Color })
+                    .ToList()
+            };
+        }
+
+        private void LoadWorkspaceTags(Workspace workspace)
+        {
+            var tagCollection = new ObservableCollection<EditableTag>();
+            if (workspace?.Tags != null)
+            {
+                workspace.Tags.ForEach(x => tagCollection.Add(new EditableTag
+                {
+                    Color = x.Color,
+                    Name = x.Name
+                }));
+            }
+            TagManagement.Tags = tagCollection;
+        }
+
+        /// <summary>
+        /// Stores the tags currently shown in the editor back into the selected working workspace.
+        /// </summary>
+        private void CommitTagsToSelectedWorkspace()
+        {
+            if (_selectedEditWorkspace == null)
+                return;
+
+            _selectedEditWorkspace.Tags = TagManagement.Tags
+                .Select(x => new Tag { Name = x.Name, Color = x.Color })
+                .ToList();
+        }
+
+        private void CbTagWorkspace_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isLoadingWorkspaces)
+                return;
+
+            // Persist edits made to the previously selected workspace before switching.
+            CommitTagsToSelectedWorkspace();
+
+            if (CbTagWorkspace.SelectedItem is string name)
+            {
+                _selectedEditWorkspace = _editWorkspaces.FirstOrDefault(w =>
+                    string.Equals(w.Name, name, StringComparison.OrdinalIgnoreCase));
+                LoadWorkspaceTags(_selectedEditWorkspace);
+            }
+        }
+
+        private void BtnAddWorkspace_Click(object sender, RoutedEventArgs e)
+        {
+            var name = TbWorkspaceName.Text?.Trim();
+            if (string.IsNullOrEmpty(name))
+            {
+                Logger.LogWarning("Enter a workspace name first.");
+                return;
+            }
+            if (_editWorkspaces.Any(w => string.Equals(w.Name, name, StringComparison.OrdinalIgnoreCase)))
+            {
+                Logger.LogWarning($"A workspace named '{name}' already exists.");
+                return;
+            }
+
+            CommitTagsToSelectedWorkspace();
+
+            var newWorkspace = new Workspace { Name = name };
+            _editWorkspaces.Add(newWorkspace);
+            _selectedEditWorkspace = newWorkspace;
+
+            _isLoadingWorkspaces = true;
+            try
+            {
+                CbTagWorkspace.Items.Add(name);
+                CbTagWorkspace.SelectedItem = name;
+            }
+            finally
+            {
+                _isLoadingWorkspaces = false;
+            }
+
+            LoadWorkspaceTags(newWorkspace);
+            TbWorkspaceName.Text = string.Empty;
+        }
+
+        private void BtnRenameWorkspace_Click(object sender, RoutedEventArgs e)
+        {
+            if (_selectedEditWorkspace == null)
+                return;
+
+            var name = TbWorkspaceName.Text?.Trim();
+            if (string.IsNullOrEmpty(name))
+            {
+                Logger.LogWarning("Enter the new workspace name first.");
+                return;
+            }
+            if (_editWorkspaces.Any(w => w != _selectedEditWorkspace &&
+                                         string.Equals(w.Name, name, StringComparison.OrdinalIgnoreCase)))
+            {
+                Logger.LogWarning($"A workspace named '{name}' already exists.");
+                return;
+            }
+
+            _selectedEditWorkspace.Name = name;
+
+            _isLoadingWorkspaces = true;
+            try
+            {
+                CbTagWorkspace.Items.Clear();
+                foreach (var ws in _editWorkspaces)
+                    CbTagWorkspace.Items.Add(ws.Name);
+                CbTagWorkspace.SelectedItem = name;
+            }
+            finally
+            {
+                _isLoadingWorkspaces = false;
+            }
+
+            TbWorkspaceName.Text = string.Empty;
+        }
+
+        private void BtnDeleteWorkspace_Click(object sender, RoutedEventArgs e)
+        {
+            if (_selectedEditWorkspace == null)
+                return;
+
+            if (_editWorkspaces.Count <= 1)
+            {
+                Logger.LogWarning("At least one workspace is required.");
+                return;
+            }
+
+            var result = MessageBox.Show(
+                $"Delete the workspace '{_selectedEditWorkspace.Name}' and all of its tags?",
+                "Delete Workspace", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            if (result != MessageBoxResult.Yes)
+                return;
+
+            _editWorkspaces.Remove(_selectedEditWorkspace);
+            _selectedEditWorkspace = _editWorkspaces[0];
+
+            _isLoadingWorkspaces = true;
+            try
+            {
+                CbTagWorkspace.Items.Clear();
+                foreach (var ws in _editWorkspaces)
+                    CbTagWorkspace.Items.Add(ws.Name);
+                CbTagWorkspace.SelectedItem = _selectedEditWorkspace.Name;
+            }
+            finally
+            {
+                _isLoadingWorkspaces = false;
+            }
+
+            LoadWorkspaceTags(_selectedEditWorkspace);
+        }
+
+        #endregion
 
         private void PopulateRenderSettingsControls()
         {
@@ -206,14 +406,19 @@ namespace ClipCull.Controls
 
         public void BtnSave_Click(object sender, RoutedEventArgs e)
         {
-            var newTags = new List<Tag>();
-            TagManagement.Tags.ToList().ForEach(x => newTags.Add(new Models.Tag
-            {
-                Color = x.Color,
-                Name = x.Name
-            }));
+            // Commit pending tag edits and persist the workspaces.
+            CommitTagsToSelectedWorkspace();
 
-            SettingsHandler.Settings.Tags = newTags;
+            SettingsHandler.Settings.Workspaces = _editWorkspaces
+                .Select(CloneWorkspace)
+                .ToList();
+
+            // Keep the active workspace valid (e.g. if it was renamed or deleted here).
+            if (SettingsHandler.Settings.Workspaces.All(w =>
+                    !string.Equals(w.Name, SettingsHandler.Settings.CurrentWorkspaceName, StringComparison.OrdinalIgnoreCase)))
+            {
+                SettingsHandler.Settings.CurrentWorkspaceName = SettingsHandler.Settings.Workspaces[0].Name;
+            }
 
             // Save numeric values from textboxes
             if (int.TryParse(TbQuality.Text, out int quality))
@@ -227,6 +432,10 @@ namespace ClipCull.Controls
 
             SettingsHandler.Save();
             HotkeyController.SaveMappings();
+
+            // Refresh tag dropdowns and the workspace selector with the new workspace set.
+            SettingsHandler.NotifyWorkspaceChanged();
+
             Logger.LogSuccess("Settings saved successfully.");
         }
 

--- a/ClipCull/ClipCull/Controls/SettingsControl.xaml.cs
+++ b/ClipCull/ClipCull/Controls/SettingsControl.xaml.cs
@@ -75,22 +75,49 @@ namespace ClipCull.Controls
                 if (_editWorkspaces.Count == 0)
                     _editWorkspaces.Add(new Workspace { Name = SettingsHandler.DefaultWorkspaceName });
 
-                CbTagWorkspace.Items.Clear();
-                foreach (var ws in _editWorkspaces)
-                    CbTagWorkspace.Items.Add(ws.Name);
-
                 // Prefer the currently active workspace as the initial selection.
                 var initial = _editWorkspaces.FirstOrDefault(w =>
                                   string.Equals(w.Name, SettingsHandler.Settings.CurrentWorkspaceName, StringComparison.OrdinalIgnoreCase))
                               ?? _editWorkspaces[0];
 
                 _selectedEditWorkspace = initial;
-                CbTagWorkspace.SelectedItem = initial.Name;
+                RepopulateWorkspaceCombos(initial.Name);
                 LoadWorkspaceTags(initial);
             }
             finally
             {
                 _isLoadingWorkspaces = false;
+            }
+        }
+
+        /// <summary>
+        /// Rebuilds both workspace dropdowns from the working list. The edit combo is set to
+        /// <paramref name="selectInEditCombo"/>; the target combo defaults to a different workspace.
+        /// </summary>
+        private void RepopulateWorkspaceCombos(string selectInEditCombo)
+        {
+            bool previous = _isLoadingWorkspaces;
+            _isLoadingWorkspaces = true;
+            try
+            {
+                CbTagWorkspace.Items.Clear();
+                CbTargetWorkspace.Items.Clear();
+                foreach (var ws in _editWorkspaces)
+                {
+                    CbTagWorkspace.Items.Add(ws.Name);
+                    CbTargetWorkspace.Items.Add(ws.Name);
+                }
+
+                if (selectInEditCombo != null)
+                    CbTagWorkspace.SelectedItem = selectInEditCombo;
+
+                CbTargetWorkspace.SelectedItem =
+                    _editWorkspaces.FirstOrDefault(w => !string.Equals(w.Name, selectInEditCombo, StringComparison.OrdinalIgnoreCase))?.Name
+                    ?? (_editWorkspaces.Count > 0 ? _editWorkspaces[0].Name : null);
+            }
+            finally
+            {
+                _isLoadingWorkspaces = previous;
             }
         }
 
@@ -168,19 +195,102 @@ namespace ClipCull.Controls
             _editWorkspaces.Add(newWorkspace);
             _selectedEditWorkspace = newWorkspace;
 
-            _isLoadingWorkspaces = true;
-            try
-            {
-                CbTagWorkspace.Items.Add(name);
-                CbTagWorkspace.SelectedItem = name;
-            }
-            finally
-            {
-                _isLoadingWorkspaces = false;
-            }
-
+            RepopulateWorkspaceCombos(name);
             LoadWorkspaceTags(newWorkspace);
             TbWorkspaceName.Text = string.Empty;
+        }
+
+        private void BtnDuplicateWorkspace_Click(object sender, RoutedEventArgs e)
+        {
+            if (_selectedEditWorkspace == null)
+                return;
+
+            // Make sure the editor's pending tag edits are part of the duplicate.
+            CommitTagsToSelectedWorkspace();
+
+            var requested = TbWorkspaceName.Text?.Trim();
+            var name = MakeUniqueWorkspaceName(
+                string.IsNullOrEmpty(requested) ? _selectedEditWorkspace.Name + " copy" : requested);
+
+            var duplicate = CloneWorkspace(_selectedEditWorkspace);
+            duplicate.Name = name;
+
+            _editWorkspaces.Add(duplicate);
+            _selectedEditWorkspace = duplicate;
+
+            RepopulateWorkspaceCombos(name);
+            LoadWorkspaceTags(duplicate);
+            TbWorkspaceName.Text = string.Empty;
+        }
+
+        /// <summary>
+        /// Returns a workspace name based on <paramref name="baseName"/> that is not yet in use.
+        /// </summary>
+        private string MakeUniqueWorkspaceName(string baseName)
+        {
+            if (!_editWorkspaces.Any(w => string.Equals(w.Name, baseName, StringComparison.OrdinalIgnoreCase)))
+                return baseName;
+
+            for (int i = 2; ; i++)
+            {
+                var candidate = $"{baseName} {i}";
+                if (!_editWorkspaces.Any(w => string.Equals(w.Name, candidate, StringComparison.OrdinalIgnoreCase)))
+                    return candidate;
+            }
+        }
+
+        private void BtnCopyTags_Click(object sender, RoutedEventArgs e) => TransferSelectedTags(move: false);
+
+        private void BtnMoveTags_Click(object sender, RoutedEventArgs e) => TransferSelectedTags(move: true);
+
+        /// <summary>
+        /// Copies (or moves) the tags selected in the list into the chosen target workspace.
+        /// </summary>
+        private void TransferSelectedTags(bool move)
+        {
+            if (CbTargetWorkspace.SelectedItem is not string targetName)
+            {
+                Logger.LogWarning("Select a target workspace first.");
+                return;
+            }
+
+            var target = _editWorkspaces.FirstOrDefault(w =>
+                string.Equals(w.Name, targetName, StringComparison.OrdinalIgnoreCase));
+            if (target == null)
+                return;
+
+            if (target == _selectedEditWorkspace)
+            {
+                Logger.LogWarning("Target workspace must differ from the current one.");
+                return;
+            }
+
+            var selected = TagManagement.GetSelectedTags();
+            if (selected.Count == 0)
+            {
+                Logger.LogWarning("Select one or more tags in the list first.");
+                return;
+            }
+
+            if (target.Tags == null)
+                target.Tags = new List<Tag>();
+
+            int transferred = 0;
+            foreach (var tag in selected)
+            {
+                if (target.Tags.Any(t => string.Equals(t.Name, tag.Name, StringComparison.OrdinalIgnoreCase)))
+                    continue;
+                target.Tags.Add(new Tag { Name = tag.Name, Color = tag.Color });
+                transferred++;
+            }
+
+            if (move)
+            {
+                TagManagement.RemoveTagsByName(selected.Select(t => t.Name));
+                CommitTagsToSelectedWorkspace();
+            }
+
+            Logger.LogSuccess($"{(move ? "Moved" : "Copied")} {transferred} tag(s) to '{target.Name}'.");
         }
 
         private void BtnRenameWorkspace_Click(object sender, RoutedEventArgs e)
@@ -203,19 +313,7 @@ namespace ClipCull.Controls
 
             _selectedEditWorkspace.Name = name;
 
-            _isLoadingWorkspaces = true;
-            try
-            {
-                CbTagWorkspace.Items.Clear();
-                foreach (var ws in _editWorkspaces)
-                    CbTagWorkspace.Items.Add(ws.Name);
-                CbTagWorkspace.SelectedItem = name;
-            }
-            finally
-            {
-                _isLoadingWorkspaces = false;
-            }
-
+            RepopulateWorkspaceCombos(name);
             TbWorkspaceName.Text = string.Empty;
         }
 
@@ -239,19 +337,7 @@ namespace ClipCull.Controls
             _editWorkspaces.Remove(_selectedEditWorkspace);
             _selectedEditWorkspace = _editWorkspaces[0];
 
-            _isLoadingWorkspaces = true;
-            try
-            {
-                CbTagWorkspace.Items.Clear();
-                foreach (var ws in _editWorkspaces)
-                    CbTagWorkspace.Items.Add(ws.Name);
-                CbTagWorkspace.SelectedItem = _selectedEditWorkspace.Name;
-            }
-            finally
-            {
-                _isLoadingWorkspaces = false;
-            }
-
+            RepopulateWorkspaceCombos(_selectedEditWorkspace.Name);
             LoadWorkspaceTags(_selectedEditWorkspace);
         }
 

--- a/ClipCull/ClipCull/Controls/TagManagementControl.xaml.cs
+++ b/ClipCull/ClipCull/Controls/TagManagementControl.xaml.cs
@@ -318,6 +318,35 @@ namespace ClipCull.Controls
         }
 
         /// <summary>
+        /// Returns the tags currently selected in the list as plain <see cref="Tag"/> objects.
+        /// </summary>
+        public List<Tag> GetSelectedTags()
+        {
+            if (TagsListView?.SelectedItems == null)
+                return new List<Tag>();
+
+            return TagsListView.SelectedItems
+                .Cast<EditableTag>()
+                .Select(ConvertToTag)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Removes the tags with the given names from the managed collection.
+        /// </summary>
+        public void RemoveTagsByName(IEnumerable<string> names)
+        {
+            if (names == null) return;
+
+            var set = new HashSet<string>(names, StringComparer.OrdinalIgnoreCase);
+            var toRemove = Tags.Where(t => set.Contains(t.Name)).ToList();
+            foreach (var tag in toRemove)
+                Tags.Remove(tag);
+
+            OnPropertyChanged(nameof(TotalTagCount));
+        }
+
+        /// <summary>
         /// Deletes the specified tag
         /// </summary>
         public void DeleteTag(EditableTag tag)

--- a/ClipCull/ClipCull/Controls/UserMetadataControl.xaml.cs
+++ b/ClipCull/ClipCull/Controls/UserMetadataControl.xaml.cs
@@ -72,6 +72,9 @@ namespace ClipCull.Controls
             // Ensure templates are loaded before we try to update them
             this.Loaded += UserMetadataControl_Loaded;
 
+            //Refresh available tags when the active workspace changes
+            SettingsHandler.WorkspaceChanged += OnWorkspaceChanged;
+
             //Subscribe Hotkeys
             HotkeyController.OnPick += HotkeyController_OnPick;
             HotkeyController.OnReject += HotkeyController_OnReject;
@@ -92,11 +95,11 @@ namespace ClipCull.Controls
 
         private void RefreshAvailableTags()
         {
-            //Tags
+            //Tags for the active workspace
             if (AvailableTags != null)
                 AvailableTags.CollectionChanged -= AvailableTags_CollectionChanged;
             AvailableTags = new ObservableCollection<Tag>();
-            SettingsHandler.Settings.Tags.ForEach(tag => AvailableTags.Add(tag));
+            SettingsHandler.GetCurrentWorkspaceTags().ForEach(tag => AvailableTags.Add(tag));
             AvailableTags.CollectionChanged += AvailableTags_CollectionChanged;
         }
 
@@ -106,8 +109,18 @@ namespace ClipCull.Controls
             if (AvailableTags == null || AvailableTags.Count == 0)
                 return;
 
-            SettingsHandler.Settings.Tags = AvailableTags.ToList();
+            // Newly created tags belong to the active workspace.
+            SettingsHandler.CurrentWorkspace.Tags = AvailableTags.ToList();
             SettingsHandler.Save();
+        }
+
+        private void OnWorkspaceChanged()
+        {
+            Dispatcher.Invoke(() =>
+            {
+                RefreshAvailableTags();
+                TagControl.AvailableTags = AvailableTags;
+            });
         }
 
         #endregion

--- a/ClipCull/ClipCull/Core/SettingsHandler.cs
+++ b/ClipCull/ClipCull/Core/SettingsHandler.cs
@@ -10,9 +10,17 @@ namespace ClipCull.Core
 {
     public static class SettingsHandler
     {
+        public const string DefaultWorkspaceName = "Default";
+
         public static string SettingsFolder = Globals.SettingsPath;
         public static string SettingsFile = Path.Combine(SettingsFolder, "settings.xml");
         public static SettingsModel Settings { get; set; }
+
+        /// <summary>
+        /// Raised when the active workspace changes or the set of workspaces is modified,
+        /// so tag dropdowns and the workspace selector can refresh.
+        /// </summary>
+        public static event Action WorkspaceChanged;
 
         public static void Initialize()
         {
@@ -35,12 +43,104 @@ namespace ClipCull.Core
                 Settings.Tags = new List<Tag>();
             }
 
+            EnsureWorkspaces();
+
             // Ensure SkipSeconds is not 0
             Settings.SkipSeconds = Settings.SkipSeconds <= 0 ? 5 : Settings.SkipSeconds;
 
             // Ensure render settings exist (may be null when loading old settings files)
             if (Settings.DefaultRenderSettings == null)
                 Settings.DefaultRenderSettings = new RenderSettings();
+        }
+
+        /// <summary>
+        /// Guarantees at least one workspace exists and migrates any legacy flat tag list
+        /// into the default workspace. Also makes sure a valid current workspace is selected.
+        /// </summary>
+        private static void EnsureWorkspaces()
+        {
+            if (Settings.Workspaces == null)
+                Settings.Workspaces = new List<Workspace>();
+
+            // Migrate legacy tags (pre-workspace settings files) into a default workspace.
+            if (Settings.Workspaces.Count == 0)
+            {
+                Settings.Workspaces.Add(new Workspace
+                {
+                    Name = DefaultWorkspaceName,
+                    Tags = Settings.Tags != null ? new List<Tag>(Settings.Tags) : new List<Tag>()
+                });
+            }
+
+            // Legacy list is no longer the source of truth.
+            Settings.Tags = new List<Tag>();
+
+            foreach (var workspace in Settings.Workspaces)
+            {
+                if (workspace.Tags == null)
+                    workspace.Tags = new List<Tag>();
+            }
+
+            // Ensure the active workspace is valid.
+            if (string.IsNullOrEmpty(Settings.CurrentWorkspaceName) ||
+                Settings.Workspaces.All(w => !string.Equals(w.Name, Settings.CurrentWorkspaceName, StringComparison.OrdinalIgnoreCase)))
+            {
+                Settings.CurrentWorkspaceName = Settings.Workspaces[0].Name;
+            }
+        }
+
+        /// <summary>
+        /// The currently active workspace. Never null once settings are loaded.
+        /// </summary>
+        public static Workspace CurrentWorkspace
+        {
+            get
+            {
+                EnsureWorkspaces();
+                return Settings.Workspaces.FirstOrDefault(w =>
+                           string.Equals(w.Name, Settings.CurrentWorkspaceName, StringComparison.OrdinalIgnoreCase))
+                       ?? Settings.Workspaces[0];
+            }
+        }
+
+        /// <summary>
+        /// Tags belonging to the active workspace. These are shown in the tag dropdowns.
+        /// </summary>
+        public static List<Tag> GetCurrentWorkspaceTags()
+        {
+            return CurrentWorkspace.Tags ?? new List<Tag>();
+        }
+
+        /// <summary>
+        /// Switches the active workspace and notifies listeners. Loading existing labels on a
+        /// clip always works regardless of the active workspace; only the dropdown is filtered.
+        /// </summary>
+        public static void SetCurrentWorkspace(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                return;
+
+            EnsureWorkspaces();
+
+            var match = Settings.Workspaces.FirstOrDefault(w =>
+                string.Equals(w.Name, name, StringComparison.OrdinalIgnoreCase));
+            if (match == null)
+                return;
+
+            if (string.Equals(Settings.CurrentWorkspaceName, match.Name, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            Settings.CurrentWorkspaceName = match.Name;
+            Save();
+            NotifyWorkspaceChanged();
+        }
+
+        /// <summary>
+        /// Raises <see cref="WorkspaceChanged"/>. Call after the workspace list is edited.
+        /// </summary>
+        public static void NotifyWorkspaceChanged()
+        {
+            WorkspaceChanged?.Invoke();
         }
 
         public static void Save()

--- a/ClipCull/ClipCull/Core/SettingsHandler.cs
+++ b/ClipCull/ClipCull/Core/SettingsHandler.cs
@@ -45,6 +45,9 @@ namespace ClipCull.Core
 
             EnsureWorkspaces();
 
+            if (Settings.FolderWorkspaces == null)
+                Settings.FolderWorkspaces = new List<FolderWorkspace>();
+
             // Ensure SkipSeconds is not 0
             Settings.SkipSeconds = Settings.SkipSeconds <= 0 ? 5 : Settings.SkipSeconds;
 
@@ -141,6 +144,56 @@ namespace ClipCull.Core
         public static void NotifyWorkspaceChanged()
         {
             WorkspaceChanged?.Invoke();
+        }
+
+        /// <summary>
+        /// Returns the workspace name remembered for the given folder, or null if none.
+        /// </summary>
+        public static string GetWorkspaceForFolder(string folderPath)
+        {
+            if (string.IsNullOrEmpty(folderPath) || Settings?.FolderWorkspaces == null)
+                return null;
+
+            var normalized = NormalizeFolder(folderPath);
+            return Settings.FolderWorkspaces
+                .FirstOrDefault(f => string.Equals(NormalizeFolder(f.FolderPath), normalized, StringComparison.OrdinalIgnoreCase))
+                ?.WorkspaceName;
+        }
+
+        /// <summary>
+        /// Stores the workspace that should be active when the given folder is loaded.
+        /// </summary>
+        public static void RememberWorkspaceForFolder(string folderPath, string workspaceName)
+        {
+            if (string.IsNullOrEmpty(folderPath) || string.IsNullOrEmpty(workspaceName))
+                return;
+
+            if (Settings.FolderWorkspaces == null)
+                Settings.FolderWorkspaces = new List<FolderWorkspace>();
+
+            var normalized = NormalizeFolder(folderPath);
+            var match = Settings.FolderWorkspaces
+                .FirstOrDefault(f => string.Equals(NormalizeFolder(f.FolderPath), normalized, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null)
+            {
+                Settings.FolderWorkspaces.Add(new FolderWorkspace { FolderPath = folderPath, WorkspaceName = workspaceName });
+            }
+            else
+            {
+                if (string.Equals(match.WorkspaceName, workspaceName, StringComparison.OrdinalIgnoreCase))
+                    return;
+                match.WorkspaceName = workspaceName;
+            }
+
+            Save();
+        }
+
+        private static string NormalizeFolder(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return path;
+            return path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         }
 
         public static void Save()

--- a/ClipCull/ClipCull/MainWindow.xaml
+++ b/ClipCull/ClipCull/MainWindow.xaml
@@ -203,13 +203,31 @@
                             </Grid.ColumnDefinitions>
 
                             <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
-                                <materialDesign:PackIcon Kind="Information" 
+                                <materialDesign:PackIcon Kind="Information"
                                            Width="14" Height="14"
                                            Foreground="{StaticResource MutedForegroundBrush}"
                                            Margin="0,0,8,0"/>
-                                <TextBlock x:Name="StatusLabel" 
-                              Text="Ready" 
+                                <TextBlock x:Name="StatusLabel"
+                              Text="Ready"
                               Style="{StaticResource small}"/>
+                            </StackPanel>
+
+                            <!-- Workspace Selector -->
+                            <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+                                <materialDesign:PackIcon Kind="Tag"
+                                           Width="14" Height="14"
+                                           VerticalAlignment="Center"
+                                           Foreground="{StaticResource MutedForegroundBrush}"
+                                           Margin="0,0,6,0"/>
+                                <TextBlock Text="Workspace:"
+                                           Style="{StaticResource small}"
+                                           VerticalAlignment="Center"
+                                           Margin="0,0,6,0"/>
+                                <ComboBox x:Name="WorkspaceSelector"
+                                          MinWidth="140"
+                                          VerticalAlignment="Center"
+                                          ToolTip="Active label workspace (filters the tag dropdowns)"
+                                          SelectionChanged="WorkspaceSelector_SelectionChanged"/>
                             </StackPanel>
                         </Grid>
                     </Border>

--- a/ClipCull/ClipCull/MainWindow.xaml
+++ b/ClipCull/ClipCull/MainWindow.xaml
@@ -34,9 +34,9 @@
 
                             <!-- Left Actions -->
                             <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
-                                <Button x:Name="OpenVideoButton" 
-                            Content="Open Video File" 
-                            Click="OpenVideoButton_Click"
+                                <Button x:Name="OpenFolderButton"
+                            Content="Open Folder"
+                            Click="OpenFolderButton_Click"
                             Style="{StaticResource primary-lg}">
                                     <Button.ContentTemplate>
                                         <DataTemplate>

--- a/ClipCull/ClipCull/MainWindow.xaml.cs
+++ b/ClipCull/ClipCull/MainWindow.xaml.cs
@@ -126,9 +126,16 @@ public partial class MainWindow : Window
         this.Closing += MainWindow_Closing;
     }
 
+    private bool _updatingWorkspaceSelector;
+
     private void MainWindow_Loaded(object sender, RoutedEventArgs e)
     {
         FolderTree.JumpToFolder(SettingsHandler.Settings.LastFolderPath);
+
+        RefreshWorkspaceSelector();
+        // MainWindow_Loaded can run more than once; keep the subscription single.
+        SettingsHandler.WorkspaceChanged -= RefreshWorkspaceSelector;
+        SettingsHandler.WorkspaceChanged += RefreshWorkspaceSelector;
 
         ClipFilter.FilterCriteria = _filterCriteria;
         LayoutManager.InitializeLayoutManagement(this);
@@ -169,6 +176,45 @@ public partial class MainWindow : Window
         };
         bFolderTree.Child = FolderTree;
     }
+
+    #region Workspace Selector
+
+    /// <summary>
+    /// Repopulates the status bar workspace dropdown from settings and selects the active one.
+    /// </summary>
+    private void RefreshWorkspaceSelector()
+    {
+        if (WorkspaceSelector == null)
+            return;
+
+        _updatingWorkspaceSelector = true;
+        try
+        {
+            WorkspaceSelector.Items.Clear();
+            foreach (var workspace in SettingsHandler.Settings.Workspaces)
+            {
+                WorkspaceSelector.Items.Add(workspace.Name);
+            }
+            WorkspaceSelector.SelectedItem = SettingsHandler.CurrentWorkspace?.Name;
+        }
+        finally
+        {
+            _updatingWorkspaceSelector = false;
+        }
+    }
+
+    private void WorkspaceSelector_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_updatingWorkspaceSelector)
+            return;
+
+        if (WorkspaceSelector.SelectedItem is string name)
+        {
+            SettingsHandler.SetCurrentWorkspace(name);
+        }
+    }
+
+    #endregion
 
     private void HotkeyController_OnSave()
     {

--- a/ClipCull/ClipCull/MainWindow.xaml.cs
+++ b/ClipCull/ClipCull/MainWindow.xaml.cs
@@ -110,6 +110,7 @@ public partial class MainWindow : Window
 
         FolderTree.FolderSelected += FolderTree_FolderSelected;
         FolderTree.FileSelected += FolderTree_FileSelected;
+        FolderTree.FolderLoaded += FolderTree_FolderLoaded;
 
         VideoClipBrowser.ClipSelectionChanged += VideoClipBrowser_ClipSelectionChanged;
         ClipPreview.VideoLoaded += ClipPreview_VideoLoaded;
@@ -136,6 +137,10 @@ public partial class MainWindow : Window
         // MainWindow_Loaded can run more than once; keep the subscription single.
         SettingsHandler.WorkspaceChanged -= RefreshWorkspaceSelector;
         SettingsHandler.WorkspaceChanged += RefreshWorkspaceSelector;
+
+        // Restore the workspace remembered for the folder the browser started on.
+        if (!string.IsNullOrEmpty(FolderTree.RootPath))
+            ApplyWorkspaceForFolder(FolderTree.RootPath);
 
         ClipFilter.FilterCriteria = _filterCriteria;
         LayoutManager.InitializeLayoutManagement(this);
@@ -179,6 +184,39 @@ public partial class MainWindow : Window
 
     #region Workspace Selector
 
+    private string _currentFolderTreeRoot;
+
+    private void FolderTree_FolderLoaded(object sender, Controls.FolderSelectedEventArgs e)
+    {
+        ApplyWorkspaceForFolder(e.FolderPath);
+    }
+
+    /// <summary>
+    /// When a folder is loaded, switch to the workspace remembered for it, or remember the
+    /// current workspace for that folder if there is no association yet.
+    /// </summary>
+    private void ApplyWorkspaceForFolder(string folder)
+    {
+        if (string.IsNullOrEmpty(folder))
+            return;
+
+        _currentFolderTreeRoot = folder;
+
+        var remembered = SettingsHandler.GetWorkspaceForFolder(folder);
+        bool exists = !string.IsNullOrEmpty(remembered) &&
+                      SettingsHandler.Settings.Workspaces.Any(w =>
+                          string.Equals(w.Name, remembered, StringComparison.OrdinalIgnoreCase));
+
+        if (exists)
+        {
+            SettingsHandler.SetCurrentWorkspace(remembered);
+        }
+        else
+        {
+            SettingsHandler.RememberWorkspaceForFolder(folder, SettingsHandler.Settings.CurrentWorkspaceName);
+        }
+    }
+
     /// <summary>
     /// Repopulates the status bar workspace dropdown from settings and selects the active one.
     /// </summary>
@@ -211,6 +249,10 @@ public partial class MainWindow : Window
         if (WorkspaceSelector.SelectedItem is string name)
         {
             SettingsHandler.SetCurrentWorkspace(name);
+
+            // Tie the manual choice to the folder currently loaded in the browser.
+            if (!string.IsNullOrEmpty(_currentFolderTreeRoot))
+                SettingsHandler.RememberWorkspaceForFolder(_currentFolderTreeRoot, name);
         }
     }
 
@@ -320,30 +362,15 @@ public partial class MainWindow : Window
         }
     }
 
-    private void OpenVideoButton_Click(object sender, RoutedEventArgs e)
+    private void OpenFolderButton_Click(object sender, RoutedEventArgs e)
     {
-        // Check for unsaved changes before opening a new video
-        if (!AllowNavigation())
+        // Load a folder into the file browser, the same way the browser's own picker does.
+        string folder = DialogHelper.ChooseFolder("Select Folder", FolderTree?.RootPath ?? SettingsHandler.Settings.LastFolderPath);
+
+        if (folder.IsNullOrEmpty() || !Directory.Exists(folder))
             return;
 
-        string title = "Select Video File";
-        string filter = "Video Files|*.mp4;*.mov;*.avi;*.mkv;*.wmv;*.flv;*.webm;*.m4v|" +
-                "MP4 Files|*.mp4|" +
-                "MOV Files|*.mov|" +
-                "All Files|*.*";
-        string selectedFile = DialogHelper.ChooseFile(title, filter, initialFolder: SettingsHandler.Settings.LastFolderPath);
-
-        if (selectedFile.IsNullOrEmpty())
-            return;
-
-        // Validate file exists and is accessible
-        if (!File.Exists(selectedFile))
-        {
-            UpdateStatus("Error: Selected file does not exist.", true);
-            return;
-        }
-
-        LoadVideoFile(selectedFile);
+        FolderTree.LoadFolder(folder);
     }
 
     #region File Loading

--- a/ClipCull/ClipCull/Models/FolderWorkspace.cs
+++ b/ClipCull/ClipCull/Models/FolderWorkspace.cs
@@ -1,0 +1,12 @@
+namespace ClipCull.Models
+{
+    /// <summary>
+    /// Remembers which tag workspace was active for a given folder in the file browser,
+    /// so reloading that folder restores the matching workspace.
+    /// </summary>
+    public class FolderWorkspace
+    {
+        public string FolderPath { get; set; }
+        public string WorkspaceName { get; set; }
+    }
+}

--- a/ClipCull/ClipCull/Models/SettingsModel.cs
+++ b/ClipCull/ClipCull/Models/SettingsModel.cs
@@ -12,6 +12,7 @@ namespace ClipCull.Models
         {
             Tags = new List<Tag>();
             Workspaces = new List<Workspace>();
+            FolderWorkspaces = new List<FolderWorkspace>();
         }
 
         public bool AutosaveSidecar { get; set; }
@@ -66,6 +67,11 @@ namespace ClipCull.Models
         /// Name of the currently active workspace whose tags are offered in the dropdowns.
         /// </summary>
         public string CurrentWorkspaceName { get; set; }
+
+        /// <summary>
+        /// Remembered workspace per folder loaded in the file browser.
+        /// </summary>
+        public List<FolderWorkspace> FolderWorkspaces { get; set; }
 
         public List<HotkeyMapping> HotkeyMappings { get; set; } = new List<HotkeyMapping>();
     }

--- a/ClipCull/ClipCull/Models/SettingsModel.cs
+++ b/ClipCull/ClipCull/Models/SettingsModel.cs
@@ -11,6 +11,7 @@ namespace ClipCull.Models
         public SettingsModel()
         {
             Tags = new List<Tag>();
+            Workspaces = new List<Workspace>();
         }
 
         public bool AutosaveSidecar { get; set; }
@@ -50,7 +51,22 @@ namespace ClipCull.Models
         public bool SnapToInOutPoints { get; set; } = true;
         public double SnapSensitivityPixels { get; set; } = 10.0;
 
+        /// <summary>
+        /// Legacy flat tag list. Kept only so old settings files can be migrated into
+        /// the default workspace on load. Tags now live inside <see cref="Workspaces"/>.
+        /// </summary>
         public List<Tag> Tags { get; set; }
+
+        /// <summary>
+        /// All tag workspaces. Each workspace has its own set of labels.
+        /// </summary>
+        public List<Workspace> Workspaces { get; set; }
+
+        /// <summary>
+        /// Name of the currently active workspace whose tags are offered in the dropdowns.
+        /// </summary>
+        public string CurrentWorkspaceName { get; set; }
+
         public List<HotkeyMapping> HotkeyMappings { get; set; } = new List<HotkeyMapping>();
     }
 }

--- a/ClipCull/ClipCull/Models/Workspace.cs
+++ b/ClipCull/ClipCull/Models/Workspace.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace ClipCull.Models
+{
+    /// <summary>
+    /// A workspace groups a set of tags (labels) so the user can keep separate
+    /// tag sets for different kinds of footage (e.g. "FPV" and "Concerts").
+    /// </summary>
+    public class Workspace
+    {
+        public Workspace()
+        {
+            Tags = new List<Tag>();
+        }
+
+        /// <summary>
+        /// Unique, user facing name of the workspace.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Tags that belong to this workspace. These are the labels shown in the
+        /// tag dropdowns while this workspace is active.
+        /// </summary>
+        public List<Tag> Tags { get; set; }
+
+        public override string ToString() => Name ?? string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces workspace functionality to ClipCull, allowing users to organize tags into separate, independent sets. Each workspace maintains its own collection of tags, and users can switch between workspaces to filter which tags appear in the tag dropdowns. This is useful for managing different types of footage or projects with distinct labeling schemes.

## Key Changes

- **New Workspace Model**: Added `Workspace` class to represent a named collection of tags
- **Settings Migration**: Updated `SettingsModel` to include a `Workspaces` list and `CurrentWorkspaceName` property, with backward compatibility for legacy flat tag lists
- **SettingsHandler Enhancements**:
  - Added `EnsureWorkspaces()` to migrate legacy settings and guarantee at least one workspace exists
  - Added `CurrentWorkspace` property and `GetCurrentWorkspaceTags()` method to access the active workspace's tags
  - Added `SetCurrentWorkspace()` to switch workspaces and `WorkspaceChanged` event for UI synchronization
  - Added `DefaultWorkspaceName` constant for the default workspace

- **Settings UI Redesign**: 
  - Refactored Tags tab to include workspace management controls (add, rename, delete workspaces)
  - Added workspace selector dropdown to switch between workspaces while editing
  - Tags are now edited per-workspace with a working copy pattern (changes committed on save)

- **Main Window Integration**:
  - Added workspace selector dropdown to the status bar for quick workspace switching
  - Added `RefreshWorkspaceSelector()` to keep the dropdown synchronized with settings

- **Tag Dropdown Updates**:
  - Modified `ClipFilterControl` and `UserMetadataControl` to display only tags from the active workspace
  - Both controls now subscribe to `WorkspaceChanged` event to refresh when the active workspace changes
  - Newly created tags are added to the active workspace instead of a global list

- **UI Polish**:
  - Updated FolderTreeControl checkbox styling and label ("Folders only" instead of "Show Files")
  - Improved layout and spacing in various controls

## Implementation Details

- Workspace switching is immediate in the main window but requires saving in the settings dialog
- The active workspace is persisted in settings and restored on application restart
- Existing labels on clips load regardless of the active workspace (only the dropdown is filtered)
- At least one workspace is always required; deletion is prevented if only one remains
- Workspace names are case-insensitive for matching but preserve the user's casing

https://claude.ai/code/session_0147ECFzqe2PjJJYWH8ub5eu